### PR TITLE
feat: add support for flake references as versions and enhance docume…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,26 @@
 `mise-nix` is a backend plugin for [Mise](https://github.com/jdx/mise) that allows you to install and manage
 packages using [Nix](https://nixos.org/).
 
+## Why use this plugin?
+
+This plugin bridges the gap between Mise's simple tool management and Nix's powerful package ecosystem, giving you:
+
+- **Reproducible environments**: Pin tools to exact versions with Nix's deterministic builds
+- **Massive package selection**: Access to 100,000+ Nix packages
+- **Cross-platform consistency**: Same tools and versions across Linux, macOS, and other platforms
+- **Zero installation hassle**: No need to compile from source or manage dependencies manually
+- **Private repository support**: Install tools from your company's private Git repositories and caches
+
+Perfect for teams that want the reliability of Nix packages with the simplicity of Mise's tool management.
+
 ---
 
 ## Prerequisites
 
 Before you get started, make sure you have installed:
 
-* **[Mise](https://github.com/jdx/mise)**
+* **[Mise](https://github.com/jdx/mise)** v2025.7.8+
 * **[Nix](https://nixos.org/)**
-
----
-
-### Nix configuration
-
-To use `mise-nix`, your Nix setup must support the following experimental features. Add these lines to your Nix
-configuration file, typically located at `/etc/nix/nix.conf`:
-
-```ini
-experimental-features = nix-command flakes
-substitutes = true
-```
-
-### Optional: Restricted environments
-If you want to avoid all local builds (e.g., in CI or restricted environments), add:
-
-```ini
-max-jobs = 0
-```
-
-**Note:** With `max-jobs = 0`, Nix will fail if it cannot find the requested tool in your binary caches.
 
 ---
 
@@ -47,37 +38,35 @@ mise plugin install nix https://github.com/jbadeau/mise-nix.git
 
 ## Usage
 
-### List available versions
+### Traditional package installation (via NixHub)
+
+#### List available versions
 
 ```sh
 mise ls-remote nix:helmfile
 ```
 
-### Install a specific version
+#### Install a specific version
 
 ```sh
 mise install nix:helmfile@1.1.2
 ```
 
-### Use in a project
+#### Use in a project
 
 ```sh
 mise use nix:helmfile@1.1.2
 ```
 
-### Run the tool
+#### Run the tool
 
 ```sh
 mise exec nix:helmfile@1.1.2 -- helmfile version
 ```
 
----
+#### Version aliases
 
-## Advanced features
-
-### Version aliases
-
-`mise-nix` supports several version aliases for convenience:
+`mise-nix` supports several version aliases for convenience with NixHub packages:
 
 - `latest` - The most recent version available (including prereleases)
 - `stable` - The most recent stable version (excluding alpha, beta, rc, etc.)
@@ -89,6 +78,94 @@ mise install nix:go@stable
 # Install absolute latest (may include prereleases)
 mise install nix:go@latest
 ```
+
+**Note:** Version aliases work with traditional NixHub packages. For flake references, use specific revisions or branches in the flake URL itself.
+
+### Flake reference installation
+
+`mise-nix` also supports installing packages directly from Nix flakes using various reference formats:
+
+#### GitHub repositories
+
+```sh
+# GitHub shorthand
+mise install "nix:nix-community/emacs-overlay#emacs-git"
+
+# Full GitHub reference
+mise install "nix:github:nixos/nixpkgs#hello"
+
+# With specific revision/branch
+mise install "nix:github:nixos/nixpkgs/abc123#hello"
+```
+
+#### Git repositories
+
+```sh
+# Git HTTPS (public repositories)
+mise install "nix:git+https://github.com/user/repo.git#package"
+
+# Git HTTPS with authentication (private repositories)
+mise install "nix:git+https://username:token@github.com/company/private-repo.git#tool"
+
+# Git SSH (private repositories with SSH keys)
+mise install "nix:git+ssh://git@company.com/tools/overlay.git#tool"
+
+# With specific revision
+mise install "nix:git+https://github.com/user/repo.git?rev=abc123#package"
+```
+
+#### Local flakes
+
+```sh
+# Relative path
+mise install "nix:./my-flake#package"
+
+# Absolute path
+mise install "nix:/absolute/path/flake#tool"
+```
+
+**Security note:** Local flakes are disabled by default for security reasons. To enable local flake support, set the environment variable:
+
+```sh
+export MISE_NIX_ALLOW_LOCAL_FLAKES=true
+```
+
+When enabled, local flakes are restricted to safe paths within the current working directory to prevent access to sensitive system directories.
+
+#### Flake reference as version
+
+You can also specify a flake reference as the version, which allows for more flexible package management:
+
+```sh
+# Install with flake reference as version
+mise install "nix:hello@nixos/nixpkgs#hello"
+mise install "nix:emacs@nix-community/emacs-overlay#emacs-git"
+
+# Use in a project with flake reference version
+mise use "nix:hello@github:nixos/nixpkgs#hello"
+
+# Run with flake reference version
+mise exec "nix:emacs@nix-community/emacs-overlay#emacs-git" -- emacs --version
+```
+
+This approach provides better organization by separating the tool name from the flake source, making it easier to manage multiple sources for the same tool.
+
+#### Usage with flakes
+
+```sh
+# Use in a project
+mise use "nix:github:nixos/nixpkgs#hello"
+
+# Run the tool
+mise exec "nix:nix-community/emacs-overlay#emacs-git" -- emacs --version
+
+# List available versions (limited for flakes)
+mise ls-remote "nix:github:nixos/nixpkgs#hello"
+```
+
+---
+
+## Advanced features
 
 ### Caching and performance
 
@@ -106,6 +183,8 @@ rm ~/.cache/mise-nix/helmfile.json
 rm -rf ~/.cache/mise-nix/
 ```
 
+**Note:** Flake references bypass the plugin's metadata cache (since they don't use NixHub) but still benefit from Nix's binary caches for faster builds.
+
 ### Environment variables
 
 You can customize the plugin behavior using environment variables:
@@ -116,7 +195,76 @@ export MISE_NIX_NIXHUB_BASE_URL="https://custom-nixhub.example.com"
 
 # Use a different nixpkgs repository
 export MISE_NIX_NIXPKGS_REPO_URL="https://github.com/MyOrg/nixpkgs"
+
+# Enable local flake support (disabled by default for security)
+export MISE_NIX_ALLOW_LOCAL_FLAKES=true
 ```
+
+---
+
+## Nix configuration
+
+To use `mise-nix`, your Nix setup must support the following experimental features. Add these lines to your Nix
+configuration file, typically located at `/etc/nix/nix.conf`:
+
+```ini
+experimental-features = nix-command flakes
+substituters = https://cache.nixos.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+```
+
+### Recommended: Additional substituters
+
+For better package availability and faster builds, consider adding community binary caches:
+
+```ini
+substituters = https://cache.nixos.org https://nix-community.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:0VI8sF6Vsp2Jxw8+OFeVfYVdIY7X+GTtY+lR78QAbXs=
+```
+
+### Optional: Performance and security settings
+
+```ini
+# Allow flakes to specify their own configuration
+accept-flake-config = true
+
+# Set build parallelism (adjust based on your system)
+max-jobs = 4
+
+# For restricted environments (CI/containers) - avoid all local builds
+max-jobs = 0
+```
+
+**Note:** With `max-jobs = 0`, Nix will fail if it cannot find the requested tool in your binary caches.
+
+---
+
+## Package source comparison
+
+| Feature | NixHub packages | Flake references |
+|---------|----------------|------------------|
+| Source | Curated packages from nixhub.io | Direct from Nix flakes |
+| Version listing | Full version history | Limited (latest/local) |
+| Caching | Metadata cached for 1 hour | No metadata cache, uses Nix binary caches |
+| Version aliases | `latest`, `stable` supported | Use flake URL revisions |
+| Platform filtering | Automatic compatibility checking | Manual via flake outputs |
+| Private repos | Not supported | Supported via git+ssh and git+https |
+| Local development | Not applicable | Supported via local paths |
+
+### When to use each approach
+
+**Use NixHub packages when:**
+- You want curated, tested packages
+- You need to browse available versions easily
+- You prefer faster installation with cached metadata
+- You're using common development tools
+
+**Use flake references when:**
+- You need cutting-edge versions from upstream
+- You're working with private repositories
+- You're developing local flakes
+- You need packages not available on NixHub
+- You want to pin to specific commits/revisions
 
 ---
 
@@ -159,21 +307,36 @@ export JAVA_HOME="$(mise which java | sed 's|/bin/java||')"
 - The package may not be available on NixHub
 - Check [NixHub](https://www.nixhub.io) to verify the package exists
 - Ensure you're using the correct package name
+- For flakes, verify the flake reference and attribute path
 
 **"No compatible versions found"**
 - The package may not support your operating system or architecture
 - Check the package's platform compatibility on NixHub
+- For flakes, ensure the attribute exists in the flake outputs
+
+**"Invalid flake reference format"**
+- Ensure flake references include both URL and attribute: `url#attribute`
+- Check that the flake URL is accessible and valid
+- For private repos, ensure authentication is configured (SSH keys or HTTPS credentials)
+
+**"Local flakes are disabled for security"**
+- Local flakes are disabled by default as a security measure
+- Set `MISE_NIX_ALLOW_LOCAL_FLAKES=true` to enable local flake support
+- Ensure the local flake path is within the current working directory
+- Avoid using paths that access sensitive system directories
 
 **Build failures**
 - Ensure you have the required Nix experimental features enabled
 - Check that your Nix binary caches are accessible
 - Consider setting `max-jobs = 0` if builds are failing in restricted environments
+- For flakes, verify the flake is valid with `nix flake show <flake-url>`
 
 ### Performance tips
 
 - Package metadata is cached for 1 hour to improve performance
 - Large packages may take time to build - consider using binary caches
 - Use `stable` version alias for more predictable builds
+- Flake builds use Nix binary caches but may take longer on first run without prior cache hits
 
 ---
 

--- a/hooks/backend_list_versions.lua
+++ b/hooks/backend_list_versions.lua
@@ -1,21 +1,29 @@
 function PLUGIN:BackendListVersions(ctx)
   local helper = require("helper")
   local tool = ctx.tool
+
   if not tool or tool == "" then
     error("Tool name cannot be empty")
   end
 
+  -- If this is a flake reference, we return available versions for that flake
+  if helper.is_flake_reference(tool) then
+    local versions = helper.get_flake_versions(tool)
+    return { versions = versions }
+  end
+
+  -- Use traditional nixhub.io workflow for regular package names
   local current_os = helper.normalize_os(RUNTIME.osType)
   local current_arch = RUNTIME.archType:lower()
 
-  -- Use cached metadata for better performance
-  local success, data, response = helper.fetch_tool_metadata_cached(tool, 3600) -- 1 hour cache
+  local success, data, response = helper.fetch_tool_metadata_cached(tool, 3600)
   helper.validate_tool_metadata(success, data, tool, response)
 
   local versions = {}
   for _, release in ipairs(data.releases) do
     local version = release.version
-    if helper.is_valid_version(version) and helper.is_compatible(release.platforms_summary, current_os, current_arch) then
+    if helper.is_valid_version(version)
+        and helper.is_compatible(release.platforms_summary, current_os, current_arch) then
       table.insert(versions, version)
     end
   end

--- a/lib/cmd.lua
+++ b/lib/cmd.lua
@@ -1,0 +1,43 @@
+-- Mock cmd module for testing
+-- This file is only used during testing when the mise runtime cmd module is not available
+local M = {}
+
+function M.exec(command)
+  -- Mock implementations for testing
+  if command:match("mkdir %-p") then
+    return ""
+  elseif command:match("stat %-c %%Y") then
+    return "0"  -- Return old timestamp to force fresh fetch
+  elseif command:match("cat .*/.*%.json") then
+    return ""  -- Return empty to force fresh fetch
+  elseif command:match("test %-d .*/bin") then
+    return "yes"
+  elseif command:match("test %-e") then
+    return "yes"
+  elseif command:match("ls %-1 .*/bin") then
+    return "mockbinary"
+  elseif command:match("which nix") then
+    return "/usr/bin/nix"
+  elseif command:match("curl") then
+    -- Mock curl response for nixhub
+    return '{"releases":[{"version":"1.0.0","platforms_summary":"Linux and macOS"}]}'
+  elseif command:match("nix build") then
+    return "/nix/store/abc123-package"
+  elseif command:match("echo .* >") then
+    return ""
+  elseif command:match("pwd") then
+    return "/mock/current/dir"
+  elseif command:match("realpath") then
+    -- Mock realpath to simulate safe paths
+    local path = command:match("realpath%s+'([^']+)'")
+    if path and path:match("^/mock/current/dir") then
+      return path
+    else
+      return "INVALID"
+    end
+  else
+    return ""
+  end
+end
+
+return M

--- a/lib/json.lua
+++ b/lib/json.lua
@@ -1,0 +1,32 @@
+-- Mock json module for testing
+-- This file is only used during testing when the mise runtime json module is not available
+local M = {}
+
+function M.decode(str)
+  -- Simple JSON decoder for basic testing
+  if str == '{"releases":[{"version":"1.0.0","platforms_summary":"Linux and macOS"}]}' then
+    return {
+      releases = {
+        {version = "1.0.0", platforms_summary = "Linux and macOS"}
+      }
+    }
+  end
+  
+  -- For empty/invalid JSON
+  if str == "" or str == nil then
+    error("Invalid JSON")
+  end
+  
+  -- Basic fallback
+  return {}
+end
+
+function M.encode(obj)
+  -- Simple JSON encoder for basic testing
+  if type(obj) == "table" then
+    return "{}"
+  end
+  return tostring(obj)
+end
+
+return M

--- a/metadata.lua
+++ b/metadata.lua
@@ -1,6 +1,6 @@
 PLUGIN = {
   name = "mise-nix",
-  version = "0.7.0",
+  version = "0.8.0",
   description = "A backend plugin for Mise that allows you to install and manage packages using Nix",
   author = "jbadeau"
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,9 +1,64 @@
 #!/bin/bash
 set -e
 
-echo "Testing plugin functionality..."
+echo "Testing mise-nix plugin functionality..."
+echo "This test suite covers:"
+echo "  1. Traditional NixHub package installation and management"
+echo "  2. Flake references in version field (e.g., nix:tool@flake-ref#package)"
+echo "  3. Direct flake references as tool names (e.g., nix:flake-ref#package)"
+echo "  4. Version listing for flake references"
+echo "  5. Security features for local flakes"
+echo "  6. Directory structure validation"
+echo ""
 
-# Test basic functionality
+# Helper function to check directory structure
+check_directory_structure() {
+    local tool_spec="$1"
+    local expected_name="$2"
+    local tool_name="$(echo "$tool_spec" | cut -d: -f2 | cut -d@ -f1)"
+    
+    # Convert special characters in tool name for directory structure
+    # # gets converted to -, / gets converted to -, etc.
+    local dir_name="$(echo "$tool_name" | sed 's/#/-/g' | sed 's/\//-/g')"
+    local install_dir="$HOME/.local/share/mise/installs/nix-$dir_name"
+    
+    echo "Checking directory structure for $tool_spec..."
+    echo "  Tool name: $tool_name"
+    echo "  Directory name: $dir_name"
+    echo "  Install dir: $install_dir"
+    echo "  Expected symlink: $install_dir/$expected_name"
+    
+    # Check that the symlink exists and points to nix store
+    if [[ ! -L "$install_dir/$expected_name" ]]; then
+        echo "ERROR: Expected symlink not found at $install_dir/$expected_name"
+        echo "Available files:"
+        ls -la "$install_dir/" || echo "Directory does not exist"
+        exit 1
+    fi
+    
+    local target=$(readlink "$install_dir/$expected_name")
+    
+    # For traditional nixhub installations, there might be intermediate symlinks
+    # Resolve to final target
+    local final_target="$target"
+    if [[ "$target" =~ ^\. ]]; then
+        # Relative symlink, resolve it
+        final_target=$(readlink -f "$install_dir/$expected_name")
+    fi
+    
+    if [[ ! "$final_target" =~ ^/nix/store/ ]]; then
+        echo "ERROR: Final target does not point to nix store."
+        echo "  Direct target: $target"
+        echo "  Final target: $final_target"
+        exit 1
+    fi
+    
+    echo "✓ Directory structure correct for $tool_spec"
+}
+
+# Test 1: Traditional NixHub functionality
+echo "=== Testing Traditional NixHub functionality ==="
+
 if [[ "$(mise ls-remote nix:helmfile)" == "" ]]; then
     echo "ERROR: No versions available"
     exit 1
@@ -11,21 +66,112 @@ fi
 
 mise install nix:helmfile
 mise exec nix:helmfile -- helmfile version
+check_directory_structure "nix:helmfile" "latest"
 mise uninstall nix:helmfile
 
 # Test version
 mise install nix:helmfile@1.1.2
 mise exec nix:helmfile@1.1.2 -- helmfile version
+check_directory_structure "nix:helmfile@1.1.2" "1.1.2"
 mise uninstall nix:helmfile@1.1.2
 
 # Test stable
 mise install nix:helmfile@stable
 mise exec nix:helmfile@stable -- helmfile version
+check_directory_structure "nix:helmfile@stable" "stable"
 mise uninstall nix:helmfile@stable
 
 # Test latest
 mise install nix:helmfile@latest
 mise exec nix:helmfile@latest -- helmfile version
+check_directory_structure "nix:helmfile@latest" "latest"
 mise uninstall nix:helmfile@latest
 
-echo "All tests passed!"
+# Test 2: Flake reference in version field
+echo "=== Testing Flake Reference in Version Field ==="
+
+# Test flake reference as version (GitHub shorthand)
+mise install nix:hello@nixos/nixpkgs#hello
+mise exec nix:hello@nixos/nixpkgs#hello -- hello
+check_directory_structure "nix:hello@nixos/nixpkgs#hello" "nixos-nixpkgs#hello"
+mise uninstall nix:hello@nixos/nixpkgs#hello
+
+# Test flake reference as version (full GitHub reference)
+mise install nix:hello@github:nixos/nixpkgs#hello
+mise exec nix:hello@github:nixos/nixpkgs#hello -- hello
+check_directory_structure "nix:hello@github:nixos/nixpkgs#hello" "github:nixos-nixpkgs#hello"
+mise uninstall nix:hello@github:nixos/nixpkgs#hello
+
+# Test 3: Direct flake reference as tool name
+echo "=== Testing Direct Flake Reference as Tool Name ==="
+
+# Test direct GitHub shorthand flake reference
+mise install nix:nixos/nixpkgs#hello
+mise exec nix:nixos/nixpkgs#hello -- hello
+check_directory_structure "nix:nixos/nixpkgs#hello" "latest"
+mise uninstall nix:nixos/nixpkgs#hello
+
+# Test direct full GitHub flake reference
+mise install nix:github:nixos/nixpkgs#hello
+mise exec nix:github:nixos/nixpkgs#hello -- hello
+check_directory_structure "nix:github:nixos/nixpkgs#hello" "latest"
+mise uninstall nix:github:nixos/nixpkgs#hello
+
+# Test nixpkgs shorthand
+mise install nix:nixpkgs#hello
+mise exec nix:nixpkgs#hello -- hello
+check_directory_structure "nix:nixpkgs#hello" "latest"
+mise uninstall nix:nixpkgs#hello
+
+# Test 4: List versions for flake references
+echo "=== Testing Version Listing for Flake References ==="
+
+# Test that flake references return appropriate versions
+flake_versions=$(mise ls-remote nix:nixpkgs#hello)
+if [[ ! "$flake_versions" =~ "latest" ]]; then
+    echo "ERROR: Expected 'latest' in flake versions, got: $flake_versions"
+    exit 1
+fi
+echo "✓ Flake version listing works correctly"
+
+# Test 5: Security features (if local flakes are enabled)
+echo "=== Testing Security Features ==="
+
+if [[ "${MISE_NIX_ALLOW_LOCAL_FLAKES}" == "true" ]]; then
+    echo "Testing local flake security with MISE_NIX_ALLOW_LOCAL_FLAKES=true"
+    
+    # Create a simple test flake
+    test_flake_dir="/tmp/mise-test-flake"
+    mkdir -p "$test_flake_dir"
+    cat > "$test_flake_dir/flake.nix" << 'EOF'
+{
+  description = "Test flake for mise-nix";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.hello;
+    packages.aarch64-darwin.default = nixpkgs.legacyPackages.aarch64-darwin.hello;
+    packages.x86_64-darwin.default = nixpkgs.legacyPackages.x86_64-darwin.hello;
+  };
+}
+EOF
+    
+    # Test local flake installation (this should work with proper security warnings)
+    echo "Testing local flake installation..."
+    mise install "nix:test@$test_flake_dir#default" 2>&1 | grep -q "WARNING: Using local flake" && echo "✓ Security warning displayed for local flakes"
+    mise uninstall "nix:test@$test_flake_dir#default" || true
+    
+    # Clean up
+    rm -rf "$test_flake_dir"
+else
+    echo "Local flakes disabled (MISE_NIX_ALLOW_LOCAL_FLAKES != true) - skipping local flake tests"
+    
+    # Test that local flakes are properly blocked
+    echo "Testing that local flakes are blocked when disabled..."
+    if mise install "nix:test@./nonexistent#default" 2>&1 | grep -q "Local flakes are disabled for security"; then
+        echo "✓ Local flakes properly blocked when disabled"
+    else
+        echo "WARNING: Local flake security test could not be verified"
+    fi
+fi
+
+echo "=== All tests passed! ==="


### PR DESCRIPTION
…ntation

  - Add support for using flake references in the version field (e.g., nix:hello@nixos/nixpkgs#hello)
  - Implement security controls for local flakes with MISE_NIX_ALLOW_LOCAL_FLAKES environment variable
  - Add comprehensive flake reference support with validation and error handling
  - Enhance README with detailed flake reference documentation and usage examples
  - Add Nix configuration recommendations including binary caches and performance settings
  - Include troubleshooting section for common flake-related issues
  - Add "Why use this plugin?" section explaining value proposition
  - Clarify caching behavior differences between NixHub packages and flake references