### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/metadata.lua
+++ b/metadata.lua
@@ -1,6 +1,6 @@
 PLUGIN = {
   name = "mise-nix",
-  version = "0.14.1",
+  version = "0.16.0",
   description = "A Mise plugin that brings the power of the Nix ecosystem to your development workflow.",
   author = "jbadeau"
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.16.0 for next release

## Test plan
- N/A - version bump only