### PR TITLE
feat: add copy install mode for CI caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Environment variables can be used to configure this plugin:
 | `MISE_NIX_ALLOW_LOCAL_FLAKES` | Set to `true` to enable local flake references |
 | `MISE_NIX_NIXHUB_BASE_URL` | Custom nixhub.io URL |
 | `MISE_NIX_NIXPKGS_REPO_URL` | Custom nixpkgs repository URL |
+| `MISE_NIX_ENV_MODE` | Environment variable resolution: `auto` (default), `dev-env`, or `path-only` |
+| `MISE_NIX_LINK_PROFILE` | Multi-output link profile: `runtime` (default) or `dev` |
+| `MISE_NIX_LINK_PATHS` | Override link profile with comma-separated paths (e.g. `/bin,/share/man`) |
+| `MISE_NIX_INSTALL_MODE` | Install strategy: `symlink` (default) or `copy` (CI-friendly, see below) |
 
 Native Nix env vars are also supported:
 
@@ -181,6 +185,41 @@ Native Nix env vars are also supported:
 |----------|-------------|
 | `NIXPKGS_ALLOW_UNFREE` | Set to `1` to allow unfree packages (enables `--impure`) |
 | `NIXPKGS_ALLOW_INSECURE` | Set to `1` to allow insecure packages (enables `--impure`) |
+
+### Environment Variables
+
+Packages that expose runtime environment variables (e.g. `JAVA_HOME`, `GOROOT`) are automatically detected. At install time, `nix print-dev-env` is cached so that `mise exec` resolves env vars instantly without any Nix evaluation.
+
+### CI Caching
+
+By default, mise-nix symlinks install paths to the Nix store. This doesn't survive CI cache restores since the Nix store paths won't exist. Set `MISE_NIX_INSTALL_MODE=copy` to copy outputs into the install directory instead, making it self-contained and cacheable:
+
+```yaml
+# GitHub Actions
+env:
+  MISE_NIX_INSTALL_MODE: copy
+
+steps:
+  - uses: actions/cache@v4
+    with:
+      path: ~/.local/share/mise/installs
+      key: mise-nix-${{ hashFiles('mise.toml') }}
+  - run: mise install
+```
+
+```yaml
+# GitLab CI
+variables:
+  MISE_NIX_INSTALL_MODE: copy
+
+job:
+  cache:
+    key: mise-nix-$CI_COMMIT_REF_SLUG
+    paths:
+      - ~/.local/share/mise/installs
+  script:
+    - mise install
+```
 
 ## Nix Setup
 

--- a/lib/install.lua
+++ b/lib/install.lua
@@ -9,10 +9,27 @@ local logger = require("logger")
 
 local M = {}
 
+-- Get the install mode: symlink (default) or copy (CI-friendly)
+-- MISE_NIX_INSTALL_MODE=copy copies nix store outputs into install_path
+-- so the directory is self-contained and cacheable without the nix store.
+function M.get_install_mode()
+  return os.getenv("MISE_NIX_INSTALL_MODE") or "symlink"
+end
+
 -- Standard tool installation via symlink (PVC-optimized)
 function M.standard_tool(nix_store_path, install_path, label)
   logger.tool("Installing as standard tool: " .. label)
-  
+
+  if M.get_install_mode() == "copy" then
+    logger.debug("Using copy mode for CI cacheability")
+    shell.try_exec('rm -rf "%s"', install_path)
+    local ok, err = shell.try_exec('cp -a "%s" "%s"', nix_store_path, install_path)
+    if not ok then
+      error("Failed to copy " .. nix_store_path .. " to " .. install_path)
+    end
+    return
+  end
+
   -- In containerized environments, check if symlink already exists and is correct
   if shell.is_containerized() then
     local ok, current_target = shell.try_exec('readlink "%s" 2>/dev/null', install_path)
@@ -21,7 +38,7 @@ function M.standard_tool(nix_store_path, install_path, label)
       return
     end
   end
-  
+
   shell.symlink_force(nix_store_path, install_path)
 end
 
@@ -38,12 +55,18 @@ function M.flake_with_hash_workaround(nix_store_path, install_path)
   -- WORKAROUND: mise expects a directory named after the nix store hash for direct flake references
   local nix_hash = nix_store_path:match("/nix/store/([^/]+)")
   if not nix_hash then return end
-  
+
   local install_dir = install_path:match("^(.+)/[^/]+$")
   if not install_dir then return end
-  
+
   local hash_path = install_dir .. "/" .. nix_hash
-  
+
+  if M.get_install_mode() == "copy" then
+    shell.try_exec('rm -rf "%s"', hash_path)
+    shell.try_exec('cp -a "%s" "%s"', nix_store_path, hash_path)
+    return
+  end
+
   -- In containerized environments, check if target already points correctly to avoid unnecessary I/O
   if shell.is_containerized() then
     local ok, current_target = shell.try_exec('readlink "%s" 2>/dev/null', hash_path)
@@ -52,7 +75,7 @@ function M.flake_with_hash_workaround(nix_store_path, install_path)
       return
     end
   end
-  
+
   shell.symlink_force(nix_store_path, hash_path)
 end
 


### PR DESCRIPTION
MISE_NIX_INSTALL_MODE=copy copies nix store outputs into the install directory instead of symlinking, making it self-contained and cacheable across CI runs without requiring the nix store.